### PR TITLE
The 'reference' key doesn't seem to exist every time. Based on readme…

### DIFF
--- a/Sync/ContactDataExchange.php
+++ b/Sync/ContactDataExchange.php
@@ -179,6 +179,11 @@ class ContactDataExchange extends GeneralDataExchange
             $objectDAO = new ObjectDAO(self::OBJECT_NAME, $object->getId(), new \DateTimeImmutable($object->getModifiedTime()->format('r')));
 
             foreach ($object->dehydrate($mappedFields) as $field => $value) {
+                // The 'reference' key doesn't seem to exist every time. Based on readme it's used only for owners. Skip it.
+                if (!isset($objectFields[$field])) {
+                    continue;
+                }
+
                 try {
                     // Normalize the value from the API to what Mautic needs
                     $normalizedValue = $this->valueNormalizer->normalizeForMauticTyped($objectFields[$field], $value);


### PR DESCRIPTION
… it's used only for owners. Skip it.

This PR fixes a bug that was preventing successful test of https://github.com/mautic-inc/plugin-integrations/pull/67#issuecomment-544572386

### Steps to test
0. Log in to Vtiger instance (https://github.com/mautic-inc/plugin-integrations/pull/67#issuecomment-544386844)
1. Update http://178.128.146.96/index.php?module=Contacts&view=Detail&record=13&app=MARKETING
2. Wait 5 minutes and check that it exists in with the change you've made in Vtiger https://beta-vtiger.mautic.net/s/contacts