### PR TITLE
Maut 3280 vtiger auth

### DIFF
--- a/Form/Type/ConfigSyncFeaturesType.php
+++ b/Form/Type/ConfigSyncFeaturesType.php
@@ -55,7 +55,7 @@ class ConfigSyncFeaturesType extends AbstractType
             ChoiceType::class,
             [
                 'choices'     => [
-                    'updateOwner' => 'mautic.plugin.vtiger.updateOwner',
+                    'mautic.plugin.vtiger.updateOwner' => 'updateOwner',
                 ],
                 'expanded'    => true,
                 'multiple'    => true,
@@ -71,7 +71,7 @@ class ConfigSyncFeaturesType extends AbstractType
             ChoiceType::class,
             [
                 'choices'     => [
-                    'updateDncByDate' => 'mautic.integrations.update.dnc.by.date',
+                    'mautic.integrations.update.dnc.by.date' => 'updateDncByDate',
                 ],
                 'expanded'    => true,
                 'multiple'    => true,
@@ -101,8 +101,8 @@ class ConfigSyncFeaturesType extends AbstractType
             ChoiceType::class,
             [
                 'choices'    => [
-                    SettingsKeyEnum::PUSH_MAUTIC_CONTACT_AS_LEAD    => 'mautic.plugin.vtiger.form.push_mautic_contact_as_lead',
-                    SettingsKeyEnum::PUSH_MAUTIC_CONTACT_AS_CONTACT => 'mautic.plugin.vtiger.form.push_mautic_contact_as_contact',
+                    'mautic.plugin.vtiger.form.push_mautic_contact_as_lead'    => SettingsKeyEnum::PUSH_MAUTIC_CONTACT_AS_LEAD,
+                    'mautic.plugin.vtiger.form.push_mautic_contact_as_contact' => SettingsKeyEnum::PUSH_MAUTIC_CONTACT_AS_CONTACT,
                 ],
                 'label'      => 'mautic.plugin.vtiger.form.push_mautic_contact_as',
                 'label_attr' => [
@@ -142,7 +142,7 @@ class ConfigSyncFeaturesType extends AbstractType
         }
         $ownersArray = [];
         foreach ($owners as $owner) {
-            $ownersArray[$owner->getId()] = (string) $owner;
+            $ownersArray[(string) $owner] = $owner->getId();
         }
 
         return $ownersArray;

--- a/Integration/Provider/VtigerConfigProvider.php
+++ b/Integration/Provider/VtigerConfigProvider.php
@@ -68,7 +68,7 @@ class VtigerConfigProvider implements ConfigFormInterface, ConfigFormSyncInterfa
     public function getSupportedFeatures(): array
     {
         return [
-            ConfigFormFeaturesInterface::FEATURE_SYNC          => 'mautic.integration.feature.sync',
+            'mautic.integration.feature.sync' => ConfigFormFeaturesInterface::FEATURE_SYNC,
             //ConfigFormFeaturesInterface::FEATURE_PUSH_ACTIVITY => 'mautic.integration.feature.push_activity',
         ];
     }

--- a/Integration/Provider/VtigerConfigProvider.php
+++ b/Integration/Provider/VtigerConfigProvider.php
@@ -68,7 +68,7 @@ class VtigerConfigProvider implements ConfigFormInterface, ConfigFormSyncInterfa
     public function getSupportedFeatures(): array
     {
         return [
-            'mautic.integration.feature.sync' => ConfigFormFeaturesInterface::FEATURE_SYNC,
+            ConfigFormFeaturesInterface::FEATURE_SYNC => 'mautic.integration.feature.sync',
             //ConfigFormFeaturesInterface::FEATURE_PUSH_ACTIVITY => 'mautic.integration.feature.push_activity',
         ];
     }


### PR DESCRIPTION
The flip of a key, value for form choices. It needs also this fix: https://github.com/mautic-inc/mautic-cloud/pull/708

Ticket: https://backlog.acquia.com/browse/MAUT-3280

Test:
Enable plugin with credentials from secure.mautic.com
Run bin/console mautic:integrations:sync VtigerCrm
